### PR TITLE
some small fixes

### DIFF
--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -26,8 +26,9 @@ function cdr(a) {
 }
 
 function eq$Qu(...args) {
+  let eq = (a,b) => a === b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
   for (var i = 1; i < args.length; ++i) {
-    if (!(args[i-1] === args[i])) {
+    if (!eq(args[i-1],args[i])) {
       return false;
     }
   }
@@ -35,8 +36,9 @@ function eq$Qu(...args) {
 }
 
 function eqv$Qu(...args) {
+  let eqv = (a,b) => a == b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
   for (var i = 1; i < args.length; ++i) {
-    if (!(args[i-1] == args[i])) {
+    if (!eqv(args[i-1], args[i])) {
       return false;
     }
   }

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -25,10 +25,31 @@ function cdr(a) {
   return a.cdr;
 }
 
+function null$Qu(a) { return (Array.isArray(a) && !a.length) }
+function boolean$Qu(a) { return typeof(a) == 'boolean' }
+function number$Qu(a) { return typeof(a) == 'number' }
+function symbol$Qu(a) { return typeof(a) == 'object' && typeof(a.symbol) == 'string' }
+
+function pair$Qu(a) {
+  return typeof(a) == 'object' && (
+           (Array.isArray(a) && a.length) || 
+           (typeof(a.car) != 'undefined' && typeof(a.cdr) != 'undefined')
+         )
+}
+
+function _binary_eqv(a, b) {
+  return (null$Qu(a) && null$Qu(b)) ||
+         (symbol$Qu(a) && symbol$Qu(b) && a.symbol == b.symbol) ||
+         (boolean$Qu(a) && boolean$Qu(b) && a == b) ||
+         (number$Qu(a) && number$Qu(b) && a == b) ||
+         a === b
+}
+
+const _binary_eq = _binary_eqv /// revise me when you want to be faster
+
 function eq$Qu(...args) {
-  var eq = (a,b) => a === b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
   for (var i = 1; i < args.length; ++i) {
-    if (!eq(args[i-1], args[i])) {
+    if (!_binary_eq(args[i-1], args[i])) {
       return false;
     }
   }
@@ -36,9 +57,8 @@ function eq$Qu(...args) {
 }
 
 function eqv$Qu(...args) {
-  var eqv = (a,b) => a == b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
   for (var i = 1; i < args.length; ++i) {
-    if (!eqv(args[i-1], args[i])) {
+    if (!_binary_eqv(args[i-1], args[i])) {
       return false;
     }
   }

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -1,154 +1,10 @@
 (import (ice-9 match))
 (import (ice-9 string-fun))
+(import (ice-9 textual-ports))
 
 ;; JavaScript Scrounged from a Simple and Straightforward Subset of Scheme
 
-(define preamble "
-function cons(a,b) { 
-  if (Array.isArray(b)) {
-    return [a].concat(b); 
-  }
-  return {car: a, cdr: b};
-}
-
-function car(a) {
-  if (Array.isArray(a)) {
-    return a[0];
-  }
-  return a.car;
-}
-
-function cdr(a) { 
-  if (Array.isArray(a)) {
-    return a.slice(1);
-  }
-  return a.cdr;
-}
-
-function null$Qu(a) { return (Array.isArray(a) && !a.length) }
-function boolean$Qu(a) { return typeof(a) == 'boolean' }
-function number$Qu(a) { return typeof(a) == 'number' }
-function symbol$Qu(a) { return typeof(a) == 'object' && typeof(a.symbol) == 'string' }
-
-function pair$Qu(a) {
-  return typeof(a) == 'object' && (
-           (Array.isArray(a) && a.length) || 
-           (typeof(a.car) != 'undefined' && typeof(a.cdr) != 'undefined')
-         )
-}
-
-function _binary_eqv(a, b) {
-  return (null$Qu(a) && null$Qu(b)) ||
-         (symbol$Qu(a) && symbol$Qu(b) && a.symbol == b.symbol) ||
-         (boolean$Qu(a) && boolean$Qu(b) && a == b) ||
-         (number$Qu(a) && number$Qu(b) && a == b) ||
-         a === b
-}
-
-const _binary_eq = _binary_eqv /// revise me when you want to be faster
-
-function eq$Qu(...args) {
-  for (var i = 1; i < args.length; ++i) {
-    if (!_binary_eq(args[i-1], args[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function eqv$Qu(...args) {
-  for (var i = 1; i < args.length; ++i) {
-    if (!_binary_eqv(args[i-1], args[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-const $Eq = eq$Qu;
-
-function $Pl(...args) {
-  var result = 0; 
-  for (var x of args) {
-    result += x;
-  }
-  return result;
-}
-
-function $Mn(...args) {
-  if (args.length <= 1) {
-    return -args[0];
-  }
-  var result = args[0];
-  for (var i = 1; i < args.length; ++i) {
-    result -= args[i];
-  }
-  return result;
-}
-
-function $St(...args) {
-  var result = 1; 
-  for (var x of args) {
-    result *= x;
-  }
-  return result;
-}
-
-function $Sl(...args) {
-  if (args.length <= 1) {
-    return 1/(args[0]);
-  }
-  var result = args[0];
-  for (var i = 1; i < args.length; ++i) {
-    result /= args[i];
-  }
-  return result;
-}
-
-function not(x) { return !x; }
-
-function $Ls(...args) {
-  for (var i = 1; i < args.length; ++i) {
-    if (!(args[i-1] < args[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function $Gt(...args) {
-  for (var i = 1; i < args.length; ++i) {
-    if (!(args[i-1] > args[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function $Ls$Eq(...args) {
-  for (var i = 1; i < args.length; ++i) {
-    if (!(args[i-1] <= args[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function $Gt$Eq(...args) {
-  for (var i = 1; i < args.length; ++i) {
-    if (!(args[i-1] >= args[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function apply(f, ...args) {
-  var collected = args.slice(0, args.length-1).concat(args[args.length-1]);
-  return f.apply(null, collected);
-}
-
-")
+(define preamble (call-with-input-file "preamble.js" get-string-all))
 
 (define (fold-left f init l)
   (match l
@@ -157,24 +13,25 @@ function apply(f, ...args) {
     (`(,h . ,t)
      (fold-left f (f init h) t))))
 
-
 (define (symbol->js expression)
-  (fold-left (lambda (string substitution)
-	       (apply string-replace-substring
-		      string
-		      substitution))
-	     (symbol->string expression)
-	     '(("+" "$Pl")
-	       ("-" "$Mn")
-	       ("*" "$St")
-	       ("/" "$Sl")
-	       ("<" "$Ls")
-	       (">" "$Gt")
-	       ("=" "$Eq")
-	       ("!" "$Ex")
-	       ("%" "$Pc")
-	       ("?" "$Qu")
-	       )))
+  (string-append "s__"
+                 (fold-left (lambda (string substitution)
+	                          (apply string-replace-substring
+		                             string
+		                             substitution))
+	                        (symbol->string expression)
+	                        '(("+" "$Pl")
+	                          ("-" "$Mn")
+	                          ("*" "$St")
+	                          ("/" "$Sl")
+	                          ("<" "$Ls")
+	                          (">" "$Gt")
+	                          ("=" "$Eq")
+	                          ("!" "$Ex")
+	                          ("%" "$Pc")
+	                          ("?" "$Qu")
+                              ("." "$Dt")
+	                          ))))
 
 (define (string-escape string)
   (fold-left (lambda (string substitution)

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -26,9 +26,9 @@ function cdr(a) {
 }
 
 function eq$Qu(...args) {
-  let eq = (a,b) => a === b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
+  var eq = (a,b) => a === b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
   for (var i = 1; i < args.length; ++i) {
-    if (!eq(args[i-1],args[i])) {
+    if (!eq(args[i-1], args[i])) {
       return false;
     }
   }
@@ -36,7 +36,7 @@ function eq$Qu(...args) {
 }
 
 function eqv$Qu(...args) {
-  let eqv = (a,b) => a == b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
+  var eqv = (a,b) => a == b || (Array.isArray(a) && Array.isArray(b) && !a.length && !b.length)
   for (var i = 1; i < args.length; ++i) {
     if (!eqv(args[i-1], args[i])) {
       return false;
@@ -206,9 +206,9 @@ function apply(f, ...args) {
     
     (`(if ,test ,then ,else)
      (string-append
-      "("(to-js test)")"
+      "(("(to-js test)")"
       "?("(to-js then)")"
-      ":("(to-js else)")"))
+      ":("(to-js else)"))"))
     
     (`(set! ,variable ,expression)
      (string-append

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -1,0 +1,42 @@
+(console.log (if (eq? () ()) 'ok '(nil != nil wtf)))
+(console.log (if (eq? () (cdr '(test))) 'ok '(nil != nil again)))
+
+(console.log (if (eq? (((lambda (sq) (lambda (*) (sq 5)))
+                        (lambda (x) (* x x)))
+                       (lambda (a b) (+ a b))) 25)
+                 'ok
+                 '(scoping problemz?)))
+
+(define (Z f) ((lambda (R) (R R)) (lambda (x) (lambda () (f (x x))))))
+(define ! ((Z (lambda (f) (lambda (n) (if (eq? n 0) 1 (* n ((f) (- n 1)))))))))
+(console.log (if (eq? (! 5) 120) 'grrreat '(lost in zee)))
+
+(define (f a b) x)
+(define x 0)
+(console.log (if (eq? (f (set! x (+ x 1)) (set! x (+ x x))) 1)
+                 '(right to left)
+                 '(left to right)))
+
+(define (shmota n acc) (if (= n 0) acc (shmota (- n 1) (cons n acc))))
+(define (iota n) (shmota n '()))
+(console.log (iota 1000)) ;;; with 10k it fails ofc
+
+(define (map f xs) (if (eq? xs '()) '() (cons (f (car xs)) (map f (cdr xs)))))
+(console.log (map (lambda (x) (* x x)) (iota 10)))
+
+(define (mk-silly n) (lambda (x) (cons x n)))
+(console.log (map (lambda (f) (f 'const)) (map mk-silly (iota 5)))) ;; gr8!
+
+(define x 23)
+(define (foo x) ((lambda (_) (* x x)) (set! x 10)))
+(console.log '(expecting 100:))
+(console.log (foo x))
+(console.log '(expecting 23:))
+(console.log x)
+
+(define x 23)
+(define (boo y) ((lambda (_) (* y y)) (set! x 10)))
+(console.log '(expecting 529:))
+(console.log (boo x))
+(console.log '(expecting 10:))
+(console.log x)

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -40,3 +40,6 @@
 (console.log (boo x))
 (console.log '(expecting 10:))
 (console.log x)
+
+(console.log ((if #t + *) 2 3))
+(console.log ((if #f + *) 2 3))

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -1,6 +1,31 @@
 (console.log (if (eq? () ()) 'ok '(nil != nil wtf)))
 (console.log (if (eq? () (cdr '(test))) 'ok '(nil != nil again)))
 
+(console.log (if (eq? 'hey 'hey) 'ok '(symbol equality broken)))
+(console.log (if (eq? 'hey 'ho) '(symbol equality broken) 'ok))
+
+(console.log (if (eq? 5 (+ 2 3)) 'ok '(eq sucks)))
+(console.log (if (eq? #t (null? '())) 'ok '(eq or null sucks)))
+(console.log (if (eq? #f (pair? '())) 'ok '(eq or pair sucks)))
+
+(console.log (if (null? ()) 'ok '(null bad)))
+(console.log (if (null? #f) '(false aint null) 'ok))
+
+(console.log (if (pair? (cons 2 3)) 'ok '(pair bad)))
+(console.log (if (pair? '(hello)) 'ok '(pair bad)))
+(console.log (if (pair? '()) '(pair bad) 'ok))
+(console.log (if (pair? (* 2 3)) '(pair bad) 'ok))
+(console.log (if (pair? #t) '(pair bad) 'ok))
+(console.log (if (pair? (eq? 2 3)) '(pair bad) 'ok))
+
+(console.log (if (number? 23) 'ok '(number bad)))
+(console.log (if (number? (* 2 3)) 'ok '(number bad)))
+(console.log (if (number? (/ 1 0)) 'ok '(number not great)))
+(console.log (if (number? 'a) '(number bad) 'ok))
+(console.log (if (number? '()) '(number bad) 'ok))
+(console.log (if (number? #f) '(number bad) 'ok))
+(console.log (if (number? #t) '(number bad) 'ok))
+
 (console.log (if (eq? (((lambda (sq) (lambda (*) (sq 5)))
                         (lambda (x) (* x x)))
                        (lambda (a b) (+ a b))) 25)
@@ -21,7 +46,7 @@
 (define (iota n) (shmota n '()))
 (console.log (iota 1000)) ;;; with 10k it fails ofc
 
-(define (map f xs) (if (eq? xs '()) '() (cons (f (car xs)) (map f (cdr xs)))))
+(define (map f xs) (if (null? xs) '() (cons (f (car xs)) (map f (cdr xs)))))
 (console.log (map (lambda (x) (* x x)) (iota 10)))
 
 (define (mk-silly n) (lambda (x) (cons x n)))
@@ -43,3 +68,8 @@
 
 (console.log ((if #t + *) 2 3))
 (console.log ((if #f + *) 2 3))
+(console.log (if '() 'ok 'nope))
+(console.log (if '(woo) 'ok 'nope))
+
+(console.log (eq? 'lambda (car ((lambda lambda lambda) 'lambda)))) ;; niiice!
+;(console.log ((lambda (if) (if 'p 'c 'a)) (lambda (a b c) (cons a (cons b (cons c)))))) ;; heh.

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -1,3 +1,6 @@
+(console.log '(1 2 3 yes we do serialize ok! (o . -)))
+(console.log '<%%!!weird-=-symbol??%%>)
+
 (console.log (if (eq? () ()) 'ok '(nil != nil wtf)))
 (console.log (if (eq? () (cdr '(test))) 'ok '(nil != nil again)))
 
@@ -13,6 +16,8 @@
 
 (console.log (if (pair? (cons 2 3)) 'ok '(pair bad)))
 (console.log (if (pair? '(hello)) 'ok '(pair bad)))
+(console.log (if (pair? '(h e l l o)) 'ok '(pair bad)))
+(console.log (if (pair? '(h e l l . o)) 'ok '(pair bad)))
 (console.log (if (pair? '()) '(pair bad) 'ok))
 (console.log (if (pair? (* 2 3)) '(pair bad) 'ok))
 (console.log (if (pair? #t) '(pair bad) 'ok))
@@ -72,4 +77,12 @@
 (console.log (if '(woo) 'ok 'nope))
 
 (console.log (eq? 'lambda (car ((lambda lambda lambda) 'lambda)))) ;; niiice!
-;(console.log ((lambda (if) (if 'p 'c 'a)) (lambda (a b c) (cons a (cons b (cons c)))))) ;; heh.
+;;(console.log ((lambda (if) (if 'p 'c 'a)) (lambda (a b c) (cons a (cons b (cons c '())))))) ;; oww, to-js needs to be aware of bound symbols then...
+
+(console.log '(now something really stupid, overwrite + with *))
+(define old-+ +)
+(set! + *)
+(define list (lambda x x))
+(console.log (list '(+ 2 3) 'is 'now (+ 2 3)))
+(set! + old-+)
+(console.log (list 'and 'now '(+ 2 3) 'is (+ 2 3) 'again))

--- a/preamble.js
+++ b/preamble.js
@@ -1,0 +1,99 @@
+var mk_seq_rel = rel => (...xs) => {
+  for(var i = 1; i < xs.length; ++i) {
+    if(!rel(xs[i-1], xs[i])) return false
+  }
+  return true
+}
+
+var internal = {
+  cons: (h,t) => Array.isArray(t) ? [h].concat(t) : {car: h, cdr: t},
+  car: p => Array.isArray(p) ? p[0] : p.car,
+  cdr: p => Array.isArray(p) ? p.slice(1) : p.cdr,
+  is_null: x => Array.isArray(x) && !x.length,
+  is_boolean: x => typeof(x) == 'boolean',
+  is_number: x => typeof(x) == 'number',
+  is_symbol: x => typeof(x) == 'object' && typeof(x.symbol) == 'string',
+  is_pair: x => typeof(x) == 'object' &&
+                ((Array.isArray(x) && x.length>0) ||
+                 (typeof(x.car) != 'undefined' &&
+                  typeof(x.cdr) != 'undefined')),
+  is_procedure: x => typeof(x) == 'function',
+  add: (...xs) => xs.reduce((n,m) => n+m, 0),
+  sub: (...xs) => xs.length>1 ? xs.reduce((n,m) => n-m) : -xs[0],
+  mul: (...xs) => xs.reduce((n,m) => n*m, 1),
+  div: (...xs) => xs.length>1 ? xs.reduce((n,m) => n/m, 1) : 1/xs[0],
+  not: x => !x,
+  gt: mk_seq_rel((n,m) => n > m),
+  lt: mk_seq_rel((n,m) => n < m),
+  gteq: mk_seq_rel((n,m) => n >= m),
+  lteq: mk_seq_rel((n,m) => n <= m),
+  app: (f, ...args) => {
+    var collected = args.slice(0, args.length-1)
+                        .concat(args[args.length-1]);
+    return f.apply(null, collected);
+  }
+}
+
+internal.eqv = mk_seq_rel(
+  (a, b) =>
+    (internal.is_null(a) && internal.is_null(b)) ||
+    (internal.is_symbol(a) && internal.is_symbol(b)
+     && a.symbol == b.symbol) ||
+    (internal.is_boolean(a) && internal.is_boolean(b) && a == b) ||
+    (internal.is_number(a) && internal.is_number(b) && a == b) ||
+    a === b
+)
+
+internal.sym2str = s => s.symbol.slice(3) /// a Provisional Solution (tm)
+                                .replaceAll("$Pl", "+")
+                                .replaceAll("$Mn", "-")
+                                .replaceAll("$St", "*")
+                                .replaceAll("$Sl", "/")
+                                .replaceAll("$Ls", "<")
+                                .replaceAll("$Gt", ">")
+                                .replaceAll("$Eq", "=")
+                                .replaceAll("$Ex", "!")
+                                .replaceAll("$Pc", "%")
+                                .replaceAll("$Qu", "?")
+                                .replaceAll("$Dt", ".")
+
+internal.serialize = e => {
+  switch(true) {
+    case internal.is_null(e): return "()"
+    case internal.is_boolean(e): return e ? "#t" : "#f"
+    case internal.is_number(e): return "" + e
+    case internal.is_symbol(e): return internal.sym2str(e)
+    case internal.is_pair(e):
+      if(Array.isArray(e)) return "(" + e.map(internal.serialize).join(" ") + ")"
+      return "(" + internal.serialize(e.car) + " . "
+                 + internal.serialize(e.cdr) + ")"
+    case internal.is_procedure(e): return "#<procedure>"
+    default: return "#<something strange>"
+  }
+}
+
+internal.console_log = e => console.log(internal.serialize(e))
+
+var s__cons = internal.cons
+var s__car = internal.car
+var s__cdr = internal.cdr
+var s__null$Qu = internal.is_null
+var s__boolean$Qu = internal.is_boolean
+var s__number$Qu = internal.is_number
+var s__symbol$Qu = internal.is_symbol
+var s__pair$Qu = internal.is_pair
+var s__procedure$Qu = internal.is_procedure
+var s__eqv$Qu = internal.eqv
+var s__eq$Qu = internal.eqv /// sic!
+var s__$Eq = s__eq$Qu
+var s__$Pl = internal.add
+var s__$Mn = internal.sub
+var s__$St = internal.mul
+var s__$Sl = internal.div
+var s__not = internal.not
+var s__$Gt = internal.gt
+var s__$Ls = internal.lt
+var s__$Gt$Eq = internal.gteq
+var s__$Ls$Eq = internal.lteq
+var s__apply = internal.app
+var s__console$Dtlog = internal.console_log


### PR DESCRIPTION
this PR fixes a few small things:

1. unlike python or ruby, js differentiates between empty lists:
```
Welcome to Node.js v18.19.0.
Type ".help" for more information.
> [] == []
false
> [] === []
false
```
it can be either fixed a'la python (,,there is just one nil'' `const $nil = []` -- but this needs to be kept track of in `cons`, `car` and `cdr` because of the array repesentation hack), or by extra contidion in eq/eqv, which this PR does.

2. `if` in rator position was tricky, so it adds extra parenthesis s.t. the following exrpression works as expected
```
((if #t + *) 2 3)
```

3. `eq?`, `eqv?` and `=` are now R5RS-compliant; a few more predicates added too.

4. symbols are prefixed to avoid clashes with js keywords; clashes with scheme are still there (e.g. commented `if` example at the end of more-tests)

5. preamble keeps the primitives inside a dictionary so that they don't pollute namespace, default symbols point at them but allow to be redefined (useless but spec-compliant).

6. silly serialization to make reading console logs easier.