### PR TITLE
fix attempt (prolly insufficient?) at js backward-shadowing of functions defined with 'function'

### DIFF
--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -92,7 +92,11 @@
       (symbol->js variable)"="(to-js expression)))
 
     (`(define (,function . ,args) . ,body)
-     (string-append
+     (to-js `(define ,function (lambda ,args . ,body)))
+     ;; can't rely on "function" keyword here since each
+     ;; redefinition shadows previous ones on pre-processing
+     ;; phsae it seems.
+     #;(string-append
       "function "(to-js function)"("(args-to-js args)"){"
       "return "(string-join (map to-js body)",")";"
       "}"))

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -86,3 +86,19 @@
 (console.log (list '(+ 2 3) 'is 'now (+ 2 3)))
 (set! + old-+)
 (console.log (list 'and 'now '(+ 2 3) 'is (+ 2 3) 'again))
+
+
+(define (list . x) x)
+
+(define evil 13)
+(console.log (list 13 'is evil))
+(define evil 23)
+(console.log (list 23 'is evil))
+
+(define (foo x) (* x x))
+(console.log '(define (foo x) (* x x)))
+(console.log (list '(foo 3) 'is (foo 3)))
+
+(define (foo x) (+ x x))
+(console.log '(define (foo x) (+ x x)))
+(console.log (list 'and 'now '(foo 3) 'is (foo 3)))


### PR DESCRIPTION
the problem with `function`s is that they seem to be collected on pre-processing phase and for each identifier only the last definition is used everywhere, e.g.
```
(define (foo x) (* x x))
(console.log '(define (foo x) (* x x)))
(define (foo x) (+ x x))
(console.log (list 'and 'now '(foo 3) 'is (foo 3)))
```
produces:
```
((foo 3) is 6)
(and now (foo 3) is 6)
```
this pr converts `(define (<f> <as> <body>)` to `(define f (λ <as> <body>)`. it can probably be done by macro-expander.
perhaps systematic renaming would do the trick too, especially that when `begin` enters the stage this problem will come back (because of `var`s "too long scope", `let`s problem with identifier re-use, inability to shadow bindings of both, and finally the sad fact that even thunks occupy js' stack, even when applied in tail-position).

alternatively some intermediate layer of heap pointers (symbols bound to pointers to objects instead of objects themself) but it seems fishy from GC point of view (and not unlikely some lookup overhead).

anyway, no need to merge this one, just pointing up the issue.