### PR TITLE
Fix lambda and stuff

### DIFF
--- a/expander.scm
+++ b/expander.scm
@@ -205,6 +205,11 @@
        ('let* ((name-2 value-2) ...)
          . body)))
 
+    (('begin expr)
+     expr)
+    (('begin . exprs)
+     (('lambda () . exprs)))
+
     (('and)
      #true)
 
@@ -471,9 +476,8 @@
 	   core-macros))
  ===> ((lambda (a)
 	 ((lambda (b)
-	    (begin
-	      ((lambda (result~0)
-		 (if result~0 result~0 (+ a b)))
-	       (> a b))))
-	  (* a 2)))
+        ((lambda (result~0)
+           (if result~0 result~0 (+ a b)))
+         (> a b)))
+      (* a 2)))
        5))

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -80,8 +80,7 @@
     (match expression
       (`(lambda ,args . ,body)
        (string-append
-	"(("(args-to-js args)")=>("(string-join
-				    (map to-js body)",")"))"))
+	"(("(args-to-js args)")=> {" (sequence-to-js body) "})"))
 
       (`(if ,test ,then ,else)
        (string-append
@@ -103,12 +102,19 @@
       (`(,function . ,args)
        (string-append (to-js function) "("(string-join
 					   (map to-js args)",")")"))
-
+      
       (_
        (if (symbol? expression)
 	   (symbol->js expression)
 	   (js-representation expression)))
       )))
+
+(define (sequence-to-js seq)
+  (match seq
+    (`(,exp)
+     (string-append "return " (to-js exp) ";"))
+    (`(,exp . ,seq*)
+     (string-append (to-js exp) ";" (sequence-to-js seq*)))))
 
 (display preamble)
 

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -85,9 +85,9 @@
 
       (`(if ,test ,then ,else)
        (string-append
-	"(("(to-js test)")"
-	"?("(to-js then)")"
-	":("(to-js else)"))"))
+	"(("(to-js test)")===false"
+	"?("(to-js else)")"
+	":("(to-js then)"))"))
 
       (`(set! ,variable ,expression)
        (string-append

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -102,3 +102,33 @@
 (define (foo x) (+ x x))
 (console.log '(define (foo x) (+ x x)))
 (console.log (list 'and 'now '(foo 3) 'is (foo 3)))
+
+(console.log
+ ((lambda ()
+    (define (sq x) (* x x))
+    (define x 5)
+    (sq x))))
+
+(console.log
+ (list 'expecting 9 'here: 
+       ((lambda (x)
+          (console.log 'ple-ple-ple)
+          (define (skwyr x) (* x x))
+          (define (ole! y) (set! x y) y)
+          (ole! (skwyr x))
+          x) (+ 2 1))))
+
+(begin
+  (console.log '(just some silly begin stuff))
+  (define (fac n) (if (= n 0) 1 (* n (fac (- n 1)))))
+  (console.log (list '(fac 5) 'is (fac 5)))
+  (define more-than-100 (fac 5))
+  (console.log (list '(and this should be sth around 14400:) (* more-than-100 more-than-100))))
+
+(console.log '(expecting (5 25 (5 5) (25 25)) below:))
+(console.log
+ (let* ((x (+ 2 3))
+        (y (* x x)))
+   (define (dup x) (list x x))
+   (list x y (dup x) (dup y))))
+

--- a/preamble.js
+++ b/preamble.js
@@ -75,7 +75,7 @@ internal.serialize = e => {
   }
 }
 
-internal.console_log = e => console.log(internal.serialize(e))
+internal.console_log = e => { console.log(internal.serialize(e)) ; return e }
 
 var s__cons = internal.cons
 var s__car = internal.car


### PR DESCRIPTION
a proposal of a few fixes/changes:

- `console.log` returns value (could be something else, the point is to not return js undefined although node seems ok with passing it from `return` so perhaps it's totally not needed; on the other hand identity-with-display can be useful for quick debugging)

- `if` semantics is ,,more correct'' since the `<else>` branch should be chosen only when `<test>` evaluates to `#f`

- added `begin` form in the expander since it has to be somewhere (other macros use it), and as of now I can't think of better translation. there might be problems with it (we'll figure out soon)

- the only relevant one: `λ` with multiple expressions in its body works now! 
```
((lambda (x)
   (define (sq x) (* x x))
   (list x (sq x)))
 (+ 2 3))
```
the main problem was that in order to have  scope (and use `var` and `;`) a block is needed. i don't think the small cases `x => x*x` vs `x => { return x*x }` matter to node/v8 since they're both pretty smart.
