### PR TITLE
desperate and ugly 'begin' fix

### DIFF
--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -76,9 +76,17 @@
 
 (define (to-js expression)
   (match expression
+
+    (`(lambda ,args (begin . ,body))
+     (to-js `(lambda ,args . ,body))) ;; :o~~~
+
+    (`(lambda ,args ,body)
+     (string-append
+      "(("(args-to-js args)")=>" (to-js body) ")"))
+
     (`(lambda ,args . ,body)
      (string-append
-      "(("(args-to-js args)")=> {" (sequence-to-js body) "})"))
+      "(("(args-to-js args)")=>{" (sequence-to-js body) "})"))
 
     (`(if ,test ,then ,else)
      (string-append

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -132,3 +132,11 @@
    (define (dup x) (list x x))
    (list x y (dup x) (dup y))))
 
+(begin
+  (define leaky-var 23)
+  (console.log (list 'leaky-var 'is leaky-var 'inside 'begin)))
+
+(console.log (list 'leaky-var 'is leaky-var 'outside 'begin 'too))
+
+(define (stupid x) (begin (console.log 'makes-no-sense-but-works) x))
+(console.log (stupid (+ 2 3)))


### PR DESCRIPTION
nie jest to nic pięknego i wydaje się prosić o problemy (zobaczymy jak dowalę wincy testów). tzn takie coś np dalej się będzie psuło
```
(define (dupa x) (display 'elo) (newline) (begin (set! x 7) (* x x)))
```
więc może to jeszcze poprawię chociaż no to powoli się robi potrzeba formy pośredniej (ze scheme'a na pre-js który na koniec możnaby dekorować takimi returnami i jakimiś ekstra nawiasami czy ich brakiem). wszystko przez to głupkowate `return` (którego np w rubym nie ma, ostatnie wyrażenie to wartość dowolnego bloku i elo).

a wgl to może `begin` sprowadzający się do thunka powinien się nazywać inaczej (ale być), jakieś `block` czy coś? bo to jest jednak nieeleganckie że nie można użyć `begin` zawierającego `define` w kontekście innym jak korzeń programu lub wnętrze lambdy (w sensie to ma sens przy tej semantyce splajsującej, ale wtedy jak chcę rzeczywiście mieć osobny zasięg odizolowany od punktu wywołania to co, muszę thunka pisać?).
albo zostawić go jako `begin`, a taki który pcha się do środowiska okalającego nazwać `begin-splicing` c'nie? (i jeszcze w lekserze pozwalać pisać `@begin`). nie wiem, ale gdyby odchodzić od scheme'a to warto by się tu zastanowić jaki sens ma ten bajzel. _bo gdyby nie mieć `begin-splicing` to nie da się zaśmiecać namespace'a akcesorami do rekordów i dwie pieczenie upieczone na jednym kamieniu c'nie?_ ;)
