### PR TITLE
revert from arrays to conses

### DIFF
--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -101,9 +101,9 @@
     (string-append "\"" (string-escape lisp-data) "\""))
    ((vector? lisp-data)
     (string-append
-     "{vector: ["
+     "["
      (string-join (map js-representation (vector->list lisp-data)) ",")
-     "]}"))))
+     "]"))))
 
 (define (args-to-js args)
   (match args
@@ -121,7 +121,7 @@
   (define (symtail as)
     (if (pair? as) (symtail (cdr as)) as))
   (let ((sym (symbol->js (symtail args))))
-    (string-append "var " sym "=__list(..." sym ");\n"))) ;; XD
+    (string-append "var " sym "=vector$Mn$Gtlist(" sym ");\n"))) ;; XD
 
 (define (to-js expression)
   (match expression

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -118,11 +118,9 @@
      (string-append "..."(symbol->js last)))))
 
 (define (unlist-dot-arg args)
-  (let* ((last-arg (let seek ((args args))
-                     (if (pair? args)
-                         (seek (cdr args))
-                         args)))
-         (sym (symbol->js last-arg)))
+  (define (symtail as)
+    (if (pair? as) (symtail (cdr as)) as))
+  (let ((sym (symbol->js (symtail args))))
     (string-append "var " sym "=__list(..." sym ");\n"))) ;; XD
 
 (define (to-js expression)

--- a/jsssssssss.scm
+++ b/jsssssssss.scm
@@ -61,7 +61,7 @@
 (define (js-representation lisp-data)
   (cond
    ((null? lisp-data)
-    "[]")
+    "__nil")
    ((symbol? lisp-data)
     (string-append "{symbol: \""(symbol->js lisp-data)"\"}"))
    ((number? lisp-data)

--- a/more-tests-expected-outputs
+++ b/more-tests-expected-outputs
@@ -2,7 +2,10 @@
 <%%!!weird-=-symbol??%%>
 (quote hehe)
 (quote (quote quote))
-"hohoho   what\na\nstrange\t\"string\"\n\\πżółćµ\\"
+hohoho   what
+a
+strange	"string"
+\πżółćµ\
 #(a b c)
 #(1 2 (a b c) () #f #t)
 ok
@@ -161,6 +164,7 @@ ok
 ok
 (expecting undefined here: #<undefined>)
 #t
+numerals------
 +inf.0
 -inf.0
 0
@@ -174,3 +178,87 @@ ok
 +inf.0
 -inf.0
 +nan.0
+(just-in-case it's a w: w)
+more-matching:
+(abc b= w)
+(elo (q w))
+(a= q)
+pff
+(w e)
+oooo
+(oto b u ł k a)
+params--------
+0
+10
+11
+0
+dots----------
+(3 4 5 6)
+(3)
+()
+(3)
+()
+map-----------
+((q . 1) (w . 2) (e . 3))
+((a x 1) (b x 2) (c x 3))
+((1 4) (2 5) (3 6))
+((a 1 4) (b 2 5) (c 3 6))
+append--------
+(he he)
+(q w e)
+(q w e a s d 1 2 3 hej ho)
+(q w e r t 1 2 3)
+(q w e r t y)
+append!-------
+(q w e 4 5 6 7 8 9)
+(q w e 4 5 6 7 8 9)
+(a b c . d)
+(e l o)
+assoc---------
+(a . 23)
+(b (quote elo))
+#f
+#f
+union---------
+(a b c e)
+(a b c d e f)
+(a b c)
+(a b c)
+(a b c)
+(a b c)
+(a b c d)
+(a b c d)
+(a (b c) c b d)
+difference----
+()
+((e))
+(a)
+(a b)
+only----------
+(2 4 6)
+(1 3 5)
+()
+(4 5 6 7)
+(4 5 6 7)
+member--------
+#f
+(x e)
+(x)
+take&drop-----
+(q w)
+(e r t y)
+(1 2 3)
+()
+fold-left-----
+15
+120
+42
+(((co ja) tu) robię?!)
+any-----------
+#t
+#f
+#f
+every---------
+#t
+#f
+#t

--- a/more-tests-expected-outputs
+++ b/more-tests-expected-outputs
@@ -91,7 +91,7 @@ ple-ple-ple
 (expecting 9 here: 9)
 (just some silly begin stuff)
 ((fac 5) is 120)
-((and this should be sth around 14400:) 14400)
+((and this should be sth around $N14400:) 14400)
 (expecting (5 25 (5 5) (25 25)) below:)
 (5 25 (5 5) (25 25))
 (leaky-var is 23 inside begin)
@@ -142,10 +142,10 @@ here-as-well
 (unquote (+ 2 3))
 (h= a t= (b c))
 (implicit begin in match works ok)
-(here is your 5:)
+(here is your $N5:)
 5
 (explicit begin in match works ok too)
-(here is another 5:)
+(here is another $N5:)
 5
 (me should be (q w e) -- (q w e))
 (i are (q w e a s d) -- (q w e a s d))

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -334,6 +334,7 @@
 (writeln (eq? 2 (cond ((assv 'b '((a 1) (b 2))) => cadr)
                       (else #f))))
 
+(writeln 'numerals------)
 
 (writeln (/ 1 0.0))
 (writeln (/ -3 0.0))
@@ -350,3 +351,137 @@
 (writeln (+ (/ -3 0.0) (/ -2 0.0)))
 
 (writeln (- (/ 3 0.0) (/ 2 0.0)))
+
+;;; niektóre tu się dublują bo je wklejam z osobnego testera, ale też
+;;; lepije 2 razy przetestować to samo niż nie przetestować ani razu!
+
+(writeln `(just-in-case it's a w: ,(cadr '(q w e))))
+
+(writeln 'more-matching:)
+(match '(q w e)
+  (`(,a) (writeln `(a= ,a)))
+  (`(,a ,b ,c) (writeln `(abc b= ,b)))
+  (`,elo (writeln `(elo ,elo))))
+
+(match '(q w)
+  (`(,a) (writeln `(a= ,a)))
+  (`(,a ,b ,c) (writeln `(abc b= ,b)))
+  (`,elo (writeln `(elo ,elo))))
+
+(match '(q)
+  (`(,a) (writeln `(a= ,a)))
+  (`(,a ,b ,c) (writeln `(abc b= ,b)))
+  (`,elo (writeln `(elo ,elo))))
+
+(match '23
+  (_ (writeln 'pff))
+  (`(,a ,b ,c) (writeln `(abc b= ,b)))
+  (`,elo (writeln `(elo ,elo))))
+
+(writeln (match '(q w e)
+           (`(,a . ,ts) ts)
+           (_ 'oooo)))
+
+(writeln (match '(q w e)
+           (`(,a ,@ts) ts)
+           (_ 'oooo)))
+
+(let ((bułka '(b u ł k a)))
+  (writeln `(oto ,@bułka)))
+
+(writeln 'params--------)
+(define p (make-parameter 0))
+(writeln (p))
+(parameterize ((p 10))
+  (writeln (p))
+  (p (+ (p) 1))
+  (writeln (p)))
+(writeln (p))
+
+(writeln 'dots----------)
+(define (kropeczka x y . zs) zs)
+(writeln (kropeczka 1 2 3 4 5 6))
+(writeln (kropeczka 1 2 3))
+(writeln (kropeczka 1 2))
+(writeln (apply kropeczka `(1 2 3)))
+(writeln (apply kropeczka `(1 2)))
+
+
+(writeln 'map-----------)
+(writeln (map cons '(q w e) '(1 2 3)))
+(writeln (map list '(a b c) '(x x x) '(1 2 3)))
+(writeln (apply map list '((1 2 3) (4 5 6))))
+(writeln (apply map list '(a b c) '((1 2 3) (4 5 6))))
+
+(writeln 'append--------)
+(writeln (append '() '() '(he he)))
+(writeln (append '(q w e) '()))
+(writeln (append '(q w e) '(a s d) '(1 2 3) '(hej ho)))
+(writeln (apply append '((q w) (e r t) (1 2 3))))
+(writeln (apply append '(() (q w e) (r t y))))
+
+(writeln 'append!-------)
+(define a '(q w e))
+(define b (append! a '(4 5 6) '(7 8 9)))
+(writeln a)
+(writeln b)
+(writeln (append! '(a b c) 'd))
+(define c '())
+(writeln (append! c '(e l o)))
+
+(writeln 'assoc---------)
+(writeln (assoc 'a '((a . 23) (b 'elo))))
+(writeln (assoc 'b '((a . 23) (b 'elo))))
+(writeln (assoc 'c '((a . 23) (b 'elo))))
+(writeln (assoc 'a '()))
+
+(writeln 'union---------)
+(writeln (union '(a b c) '(a c e)))
+(writeln (union '(a b c) '(d e f)))
+(writeln (union '(a b c) '(a b c)))
+(writeln (union '(a b c) '(c a b)))
+(writeln (union '() '(a b c)))
+(writeln (union '(a b c) '()))
+(writeln (union '(a b c) '(a b c) '(d a c) '(d d d)))
+(writeln (union '(a b c) '(a b c) '(d a c) '(d a b)))
+(writeln (union '(a (b c) c) '(a b c) '(d a (b c)) '(d a (b c))))
+
+(writeln 'difference----)
+(writeln (difference '() '(a (b c) d)))
+(writeln (difference '(a (e)) '(a (b c) d)))
+(writeln (difference '(a (e)) '(b (e) d)))
+(writeln (difference '(a b) '()))
+
+(writeln 'only----------)
+(writeln (only even? '(1 2 3 4 5 6)))
+(writeln (only odd? '(1 2 3 4 5 6)))
+(writeln (only even? '()))
+(writeln (only (lambda (x) (> x 3)) '(1 2 3 4 5 6 7)))
+(writeln (only (lambda (x) (is x > 3)) '(1 2 3 4 5 6 7)))
+
+(writeln 'member--------)
+(writeln (member 'x '(q w e)))
+(writeln (member 'x '(q x e)))
+(writeln (member 'x '(q w x)))
+
+(writeln 'take&drop-----)
+(writeln (take 2 '(q w e r t y)))
+(writeln (drop 2 '(q w e r t y)))
+(writeln (take 5 '(1 2 3)))
+(writeln (drop 5 '(1 2 3)))
+
+(writeln 'fold-left-----)
+(writeln (fold-left + 0 '(1 2 3 4 5)))
+(writeln (fold-left * 1 '(1 2 3 4 5)))
+(writeln (fold-left + 42 '()))
+(writeln (fold-left (lambda x x) 'co '(ja tu robię?!)))
+
+(writeln 'any-----------)
+(writeln (any even? '(1 2 3 4 5)))
+(writeln (any even? '(1 3 5)))
+(writeln (any even? '()))
+
+(writeln 'every---------)
+(writeln (every even? '(0 2 4 6)))
+(writeln (every even? '(0 2 4 5)))
+(writeln (every even? '()))

--- a/runtime/lists.js
+++ b/runtime/lists.js
@@ -1,3 +1,5 @@
+const __nil = Symbol();
+
 var pair$Qu = x => (typeof(x) == 'object' && 'car' in x && 'cdr' in x);
 
 var cons = (h,t) => {return {car: h, cdr: t}; };
@@ -5,13 +7,13 @@ var car = p => p.car;
 var cdr = p => p.cdr;
 var cadr = p => p.cdr.car;
 
-var null$Qu = x => Array.isArray(x) && !x.length;
+var null$Qu = x => x===__nil;
 
 var list$Qu = x => (null$Qu(x) || pair$Qu(x) && list$Qu(x.cdr));
 
 var append = (...xs) => {
     xs = xs.filter(x=>!null$Qu(x));
-    if(xs.length<1) return [];
+    if(xs.length<1) return __nil;
     var res = xs[xs.length-1];
     for(var i=xs.length-2;i>=0;i--) {
         var tmp = __unlist(xs[i]);
@@ -24,7 +26,7 @@ var append = (...xs) => {
 
 var append$Ex = (...xs) => {
     xs = xs.filter(x=>!null$Qu(x));
-    if(xs.length<1) return [];
+    if(xs.length<1) return __nil;
     for(var i=0;i<xs.length-1;i++) {
         var p = xs[i];
         while(pair$Qu(p)) {
@@ -46,7 +48,7 @@ var length = xs => {
 };
 
 var __list = (...xs) => {
-    var res = [];
+    var res = __nil;
     for(var i=xs.length-1; i>=0; i--) { res = cons(xs[i],res); }
     return res;
 };
@@ -133,7 +135,7 @@ var fold$Mnleft = (op, init, l) => {
 
 var union = (...sets) => {
     switch (sets.length) {
-    case 0: return [];
+    case 0: return __nil;
     case 1: return sets[0];
     default: break;
     }
@@ -153,7 +155,7 @@ var union = (...sets) => {
 var difference = (a, b) => {
     var bset = {};
     for (var x of __unlist(b)) {
-	bset[stringify(x)] = 1;
+	bset[serialize(x)] = 1;
     }
-    return list(...__unlist(a).filter(x=> !(stringify(x) in bset)));
+    return list(...__unlist(a).filter(x=> !(serialize(x) in bset)));
 };

--- a/runtime/lists.js
+++ b/runtime/lists.js
@@ -16,7 +16,7 @@ var append = (...xs) => {
     if(xs.length<1) return __nil;
     var res = xs[xs.length-1];
     for(var i=xs.length-2;i>=0;i--) {
-        var tmp = __unlist(xs[i]);
+        var tmp = list$Mn$Gtvector(xs[i]);
         for(var j=tmp.length-1;j>=0;j--) {
             res = cons(tmp[j],res);
         }
@@ -47,20 +47,7 @@ var length = xs => {
     else throw "length wrong type argument";
 };
 
-var __list = (...xs) => {
-    var res = __nil;
-    for(var i=xs.length-1; i>=0; i--) { res = cons(xs[i],res); }
-    return res;
-};
-
-var list = __list;
-
-var __unlist = xs => {
-    var arr = [];
-    while(pair$Qu(xs)) { arr.push(xs.car); xs = xs.cdr; }
-    if(!null$Qu(xs)) throw "__unlist wrong type argument"
-    return arr;
-};
+var list = (...xs) => vector$Mn$Gtlist(xs);
 
 var member = (e, l) => {
     while(pair$Qu(l)) {
@@ -78,7 +65,7 @@ var drop = (n, l) => {
 var take = (n, l) => {
     var q = [];
     while(n>0 && pair$Qu(l)) {q.push(l.car); l = l.cdr; n -= 1;}
-    return __list(...q);
+    return vector$Mn$Gtlist(q);
 };
 
 var any = (pred, l) => {
@@ -117,12 +104,11 @@ var map = (f, ...ls) => {
         res.push(f.apply(null,args));
         ls = ls.map(x => cdr(x));        
     }
-    return __list(...res);
+    return vector$Mn$Gtlist(res);
 }
 
-var only = (pred, l) => __list(...__unlist(l).filter(pred));
+var only = (pred, l) => vector$Mn$Gtlist(list$Mn$Gtvector(l).filter(pred));
 
-//var fold$Mnleft = (op, init, l) =>  __unlist(l).reduce(op, init);
 var fold$Mnleft = (op, init, l) => {
     var acc = init;
     while(pair$Qu(l)) {
@@ -141,7 +127,7 @@ var union = (...sets) => {
     }
     var set = {};
     for (var s of sets) {
-	    for (var x of __unlist(s)) {
+	    for (var x of list$Mn$Gtvector(s)) {
 	        set[serialize(x)] = x;
 	    }
     }
@@ -149,13 +135,13 @@ var union = (...sets) => {
     for (var k in set) {
 	result.push(set[k]);
     }
-    return __list(...result);
+    return vector$Mn$Gtlist(result);
 };
 
 var difference = (a, b) => {
     var bset = {};
-    for (var x of __unlist(b)) {
+    for (var x of list$Mn$Gtvector(b)) {
 	bset[serialize(x)] = 1;
     }
-    return list(...__unlist(a).filter(x=> !(serialize(x) in bset)));
+    return vector$Mn$Gtlist(list$Mn$Gtvector(a).filter(x=> !(serialize(x) in bset)));
 };

--- a/runtime/lists.js
+++ b/runtime/lists.js
@@ -1,14 +1,8 @@
-/*
-var pair$Qu = x => (typeof(x) == 'object'
-	                && typeof(x.car) != 'undefined'
-                    && typeof(x.cdr) != 'undefined');
-*/
-
 var pair$Qu = x => (typeof(x) == 'object' && 'car' in x && 'cdr' in x);
 
 var cons = (h,t) => {return {car: h, cdr: t}; };
-var car = p => {return p.car} ;
-var cdr = p => {return p.cdr} ;
+var car = p => p.car;
+var cdr = p => p.cdr;
 var cadr = p => p.cdr.car;
 
 var null$Qu = x => Array.isArray(x) && !x.length;
@@ -47,3 +41,58 @@ var __unlist = xs => {
     if(!null$Qu(xs)) throw "__unlist wrong type argument"
     return arr;
 };
+
+var member = (e, l) => {
+    while(pair$Qu(l)) {
+        if(equal$Qu(e, l.car)) return true;
+        l = l.cdr;
+    }
+    return false;
+};
+
+var drop = (n, l) => {
+    while(n>0) { l = l.cdr; n -= 1; }
+    return l;
+};
+
+var take = (n, l) => {
+    var q = [];
+    while(n>0) {q.push(l.car); l = l.cdr; n -= 1;}
+    return __list(...q);
+};
+
+var any = (pred, l) => {
+    while(pair$Qu(l)) {
+        if(pred(l.car)) return true;
+        l = l.cdr;
+    }
+    return false;
+};
+
+var every = (pred, l) => {
+    while(pair$Qu(l)) {
+        if(!pred(l.car)) return false;
+        l = l.cdr;
+    }
+    return true;
+};
+
+var assoc = (key, alist) => {
+    while(pair$Qu(alist)) {
+	    if(equal$Qu(alist.car.car, key)) return alist.car;
+	    alist = alist.cdr;
+    }
+    return false;
+};
+
+var for$Mneach = (f, l) => {
+    while(pair$Qu(l)) { f(l.car); l=l.cdr; }
+};
+
+/// wot bootstrapping c'nie
+var map1 = ((f,xs)=>{return ((null$Qu(xs))===false?(cons(f(car(xs)),map1(f,cdr(xs)))):([]));});
+var map = ((f,...xs)=>{var xs=__list(...xs);return ((pair$Qu(car(xs)))===false?([]):(cons(apply(f,map1(car,xs)),apply(map,f,map1(cdr,xs)))));});
+/// no sorki
+var only = (pred, l) => __list(...__unlist(l).filter(pred));
+var fold$Mnleft = (op, init, l) => __unlist(l).reduce(op, init);
+

--- a/runtime/numbers.js
+++ b/runtime/numbers.js
@@ -20,3 +20,6 @@ var string$Mn$Gtnumber = (s, radix=10) => {
 
 var finite$Qu = isFinite;
 var nan$Qu = isNaN;
+
+var even$Qu = n => number$Qu(n) && n%2==0;
+var odd$Qu = n => number$Qu(n) && n%2==1;

--- a/runtime/primops.js
+++ b/runtime/primops.js
@@ -43,7 +43,7 @@ var $Ls$Eq = mk_seq_rel((n,m) => n <= m);
 
 var apply = (f, ...args) => {
     var collected = args.slice(0, args.length-1)
-        .concat(__unlist(args[args.length-1]));
+        .concat(list$Mn$Gtvector(args[args.length-1]));
     return f.apply(null, collected);
 };
 

--- a/runtime/primops.js
+++ b/runtime/primops.js
@@ -43,7 +43,7 @@ var $Ls$Eq = mk_seq_rel((n,m) => n <= m);
 
 var apply = (f, ...args) => {
     var collected = args.slice(0, args.length-1)
-        .concat(args[args.length-1]);
+        .concat(__unlist(args[args.length-1]));
     return f.apply(null, collected);
 };
 

--- a/runtime/serialize.js
+++ b/runtime/serialize.js
@@ -1,5 +1,6 @@
 var serialize = e => {
     switch(true) {
+    //case e==undefined: return "#<undefined>";
     case null$Qu(e): return "()";
     case boolean$Qu(e): return e ? "#t" : "#f";
     case number$Qu(e): return number$Mn$Gtstring(e);
@@ -8,13 +9,14 @@ var serialize = e => {
     case string$Qu(e): return JSON.stringify(e);
     case vector$Qu(e): return "#("+e.vector.map(serialize).join(" ")+")";
     case pair$Qu(e):
-	if(Array.isArray(e))
-	    return "("+e.map(serialize).join(" ")+")";
-	if (improper$Qu(e))
-	    return "("+e.improper.map(serialize).join(" ")
-	    + " . " + serialize(e.tail) + ")";
-	return "(" + serialize(e.car) + " . "
-            + serialize(e.cdr) + ")";
+        var str = "(";
+        while(true) {
+            str += serialize(e.car);
+            if(null$Qu(e.cdr)) { return str + ")"; }
+            str += " ";
+            if(pair$Qu(e.cdr)) { e = e.cdr; }
+            else { return str += ". " + serialize(e.cdr) + ")"; }
+        }
     case procedure$Qu(e): return "#<"+e.toString()+">";
     case eof$Mnobject$Qu(e): return "#<eof-object>";
     default:
@@ -70,9 +72,7 @@ let stringify = (e) => {
     return serialize(e);
 }
 
-var writeln = (...args) => {
-    console.log(args.map(stringify).join(''));
-};
+var writeln = es => console.log(serialize(es));
 
 var error = (...msg) => { throw new Error(msg.map(stringify).join('')); };
 

--- a/runtime/serialize.js
+++ b/runtime/serialize.js
@@ -1,6 +1,5 @@
 var serialize = e => {
     switch(true) {
-    //case e==undefined: return "#<undefined>";
     case null$Qu(e): return "()";
     case boolean$Qu(e): return e ? "#t" : "#f";
     case number$Qu(e): return number$Mn$Gtstring(e);
@@ -31,13 +30,11 @@ var serialize = e => {
 };
 
 let arrays$Mnequal$Qu = (a, b) => {
-    if (a.length != b.length) {
-	return false;
-    }
+    if (a.length != b.length) return false;
     for (var i = 0; i < a.length; ++i) {
-	if (!equal$Qu(a[i], b[i])) {
-	    return false;
-	}
+	    if (!equal$Qu(a[i], b[i])) {
+	        return false;
+	    }
     }
     return true;
 }
@@ -45,34 +42,26 @@ let arrays$Mnequal$Qu = (a, b) => {
 let objects$Mnequal$Qu = (a, b) => {
     var a_keys = Object.keys(a);
     var b_keys = Object.keys(b);
-    if (a_keys.length != b_keys.length) {
-	return false;
-    }
+    if (a_keys.length != b_keys.length) return false;
     for (var x of a_keys) {
-	if (!(x in b) || !equal$Qu(a[x], b[x])) {
-	    return false;
-	}
+	    if (!(x in b) || !equal$Qu(a[x], b[x])) return false;
     }
     return true;
 }
 
-var __equal2 = (x,y) => (eq$Qu(x,y)
-                         || (vector$Qu(x) && vector$Qu(y) && 
-                             arrays$Mnequal$Qu(x.vector, y.vector))
-                         || (pair$Qu(x) && pair$Qu(y) &&
-                             __equal2(x.car, y.car) &&
-                             __equal2(x.cdr, y.cdr)));
-
+var __equal2 = (x,y) => (x === y ||
+                         (typeof(x)==typeof(y) &&
+                         ((typeof(x)=='object' && objects$Mnequal$Qu(x,y))
+                          || (pair$Qu(x) && pair$Qu(y) &&
+                            __equal2(x.car, y.car) &&
+                            __equal2(x.cdr, y.cdr)))));
 var equal$Qu = mk_seq_rel(__equal2);
 
-let stringify = (e) => {
-    if(string$Qu(e)) {
-	return e;
-    }
-    return serialize(e);
-}
+let stringify = (e) => string$Qu(e)?e:serialize(e);
 
-var writeln = es => console.log(serialize(es));
+var writeln = (...args) => {
+    console.log(args.map(stringify).join(''));
+};
 
 var error = (...msg) => { throw new Error(msg.map(stringify).join('')); };
 

--- a/runtime/serialize.js
+++ b/runtime/serialize.js
@@ -6,7 +6,7 @@ var serialize = e => {
     case char$Qu(e): return "#\\"+charName(e);
     case symbol$Qu(e): return symbol$Mn$Gtstring(e);
     case string$Qu(e): return JSON.stringify(e);
-    case vector$Qu(e): return "#("+e.vector.map(serialize).join(" ")+")";
+    case vector$Qu(e): return "#("+e.map(serialize).join(" ")+")";
     case pair$Qu(e):
         var str = "(";
         while(true) {

--- a/runtime/serialize.js
+++ b/runtime/serialize.js
@@ -56,14 +56,14 @@ let objects$Mnequal$Qu = (a, b) => {
     return true;
 }
 
-var equal$Qu = mk_seq_rel((x,y) => {
-    return x === y
-	|| (typeof(x) == typeof(y)
-	    && ((Array.isArray(x) && Array.isArray(y)
-		 && arrays$Mnequal$Qu(x,y))
-		|| (typeof(x) == 'object'
-		    && objects$Mnequal$Qu(x, y))));
-});
+var __equal2 = (x,y) => (eq$Qu(x,y)
+                         || (vector$Qu(x) && vector$Qu(y) && 
+                             arrays$Mnequal$Qu(x.vector, y.vector))
+                         || (pair$Qu(x) && pair$Qu(y) &&
+                             __equal2(x.car, y.car) &&
+                             __equal2(x.cdr, y.cdr)));
+
+var equal$Qu = mk_seq_rel(__equal2);
 
 let stringify = (e) => {
     if(string$Qu(e)) {

--- a/runtime/strings.js
+++ b/runtime/strings.js
@@ -55,7 +55,7 @@ var string$Mn$Gtsymbol = s => {
     return { symbol: name };
 };
 
-var list$Mn$Gtstring = s => __list(...s.map(c => c.char).join(''));
+var list$Mn$Gtstring = s => __unlist(s).map(c => c.char).join('');
 
 var string$Mn$Gtlist = s => __list(...s.split('').map(c =>{ return {char: c} }));
 

--- a/runtime/strings.js
+++ b/runtime/strings.js
@@ -57,9 +57,9 @@ var string$Mn$Gtsymbol = s => {
     return { symbol: name };
 };
 
-var list$Mn$Gtstring = s => __unlist(s).map(c => c.char).join('');
+var list$Mn$Gtstring = s => list$Mn$Gtvector(s).map(c => c.char).join('');
 
-var string$Mn$Gtlist = s => __list(...s.split('').map(c =>{ return {char: c} }));
+var string$Mn$Gtlist = s => vector$Mn$Gtlist(s.split('').map(c =>{ return {char: c} }));
 
 var string$Mnappend = (...args) => args.join('');
 

--- a/runtime/strings.js
+++ b/runtime/strings.js
@@ -55,15 +55,23 @@ var string$Mn$Gtsymbol = s => {
     return { symbol: name };
 };
 
-var list$Mn$Gtstring = s => s.map(c => c.char).join('');
+var list$Mn$Gtstring = s => __list(...s.map(c => c.char).join(''));
 
-var string$Mn$Gtlist = s => s.split('').map(c =>{
-    return {char: c}
-});
+var string$Mn$Gtlist = s => __list(...s.split('').map(c =>{ return {char: c} }));
 
 var string$Mnappend = (...args) => args.join('');
 
-var string$Mnjoin = (strings, joint='') => strings.join(joint);
+var string$Mnjoin = (strings, joint='') => {
+    res = "";
+    while(pair$Qu(strings)) {
+        if(!string$Qu(strings.car)) throw "string-join wrong type argument";
+        res += strings.car;
+        strings = strings.cdr;
+        if(null$Qu(strings)) return res;
+        if(!pair$Qu(strings)) throw "string-join wrong type argument";
+        res += joint;
+    }
+};
 
 let charName = c => {
     let i = c.char.codePointAt(0);

--- a/runtime/strings.js
+++ b/runtime/strings.js
@@ -31,6 +31,7 @@ var symbol$Mn$Gtstring = s => {
 	.replace(/[$]At/g, "@")
 	.replace(/[$]Tl/g, "~")
 	.replace(/[$]Dt/g, ".")
+	.replace(/[$]Am/g, "&")
 	.replace(/[$]Nm/g, "#");
 }
 
@@ -51,6 +52,7 @@ var string$Mn$Gtsymbol = s => {
 	   .replace(/[@]/g, "$At")
 	   .replace(/[~]/g, "$Tl")
 	   .replace(/[.]/g, "$Dt")
+	   .replace(/[&]/g, "$Am")
 	   .replace(/[#]/g, "$Nm"));
     return { symbol: name };
 };

--- a/runtime/vectors.js
+++ b/runtime/vectors.js
@@ -2,9 +2,9 @@ var vector$Qu = x => typeof(x) == 'object'
     && typeof(x.vector) == 'object'
     && Array.isArray(x.vector);
 
-var make$Mnvector = (k,f) => { return {vector: Array(k).fill(f)} }
+var make$Mnvector = (k,f) => { return {vector: Array(k).fill(f)} };
 
-var vector = (...xs) => {return {vector: xs} }
+var vector = (...xs) => {return {vector: xs} };
 
 var list$Mn$Gtvector = l => {
     if(!list$Qu(l) && !null$Qu(l)) throw "list->vector wrong type argument";
@@ -12,7 +12,7 @@ var list$Mn$Gtvector = l => {
     var xs = Array(ll);
     for(var i=0;i<ll;i++) { xs[i] = l.car; l = l.cdr; }
     return {vector: xs};
-}
+};
 
 var vector$Mn$Gtlist = v => __list(...v.vector);
 

--- a/runtime/vectors.js
+++ b/runtime/vectors.js
@@ -7,10 +7,14 @@ var make$Mnvector = (k,f) => { return {vector: Array(k).fill(f)} }
 var vector = (...xs) => {return {vector: xs} }
 
 var list$Mn$Gtvector = l => {
-    if(Array.isArray(l)) return {vector: l};
-    else throw "list->vector wrong type argument"
+    if(!list$Qu(l) && !null$Qu(l)) throw "list->vector wrong type argument";
+    var ll = length(l);
+    var xs = Array(ll);
+    for(var i=0;i<ll;i++) { xs[i] = l.car; l = l.cdr; }
+    return {vector: xs};
 }
-var vector$Mn$Gtlist = v => v.vector;
+
+var vector$Mn$Gtlist = v => __list(...v.vector);
 
 var vector$Mnlength = v => v.vector.length;
 

--- a/runtime/vectors.js
+++ b/runtime/vectors.js
@@ -1,25 +1,24 @@
-var vector$Qu = x => typeof(x) == 'object'
-    && typeof(x.vector) == 'object'
-    && Array.isArray(x.vector);
+var vector$Qu = x => typeof(x) == 'object' && Array.isArray(x);
 
-var make$Mnvector = (k,f) => { return {vector: Array(k).fill(f)} };
-
-var vector = (...xs) => {return {vector: xs} };
+var make$Mnvector = (k,f) => { return Array(k).fill(f); };
+var vector = (...xs) => {return xs; };
 
 var list$Mn$Gtvector = l => {
-    if(!list$Qu(l) && !null$Qu(l)) throw "list->vector wrong type argument";
-    var ll = length(l);
-    var xs = Array(ll);
-    for(var i=0;i<ll;i++) { xs[i] = l.car; l = l.cdr; }
-    return {vector: xs};
+    var v = Array(length(l));
+    for(var i=0;i<v.length;i++) { v[i] = l.car; l = l.cdr; }    
+    return v;
 };
 
-var vector$Mn$Gtlist = v => __list(...v.vector);
+var vector$Mn$Gtlist = v => {
+    var l = __nil;
+    for(var i=v.length-1; i>=0; i--) { l = cons(v[i],l); }
+    return l;
+};
 
-var vector$Mnlength = v => v.vector.length;
+var vector$Mnlength = v => v.length;
 
-var vector$Mnref = (v,k) => v.vector[k];
+var vector$Mnref = (v,k) => v[k];
 
-var vector$Mnset$Ex = (v,k,o) => v.vector[k]=o;
+var vector$Mnset$Ex = (v,k,o) => v[k]=o;
 
-var vector$Mnfill$Ex = (v,f) => v.vector.fill(f);
+var vector$Mnfill$Ex = (v,f) => v.fill(f);

--- a/test-ack.scm
+++ b/test-ack.scm
@@ -1,0 +1,13 @@
+(define (ack m n)
+  (if (= m 0)
+      (+ n 1) 
+      (if (= n 0)
+          (ack (- m 1) 1)
+          (ack (- m 1) (ack m (- n 1))))))
+
+(define (rep n f)
+  (if (= n 0)
+      #t
+      (begin (f) (rep (- n 1) f))))
+
+(rep 100 (lambda () (writeln (ack 3 10))))

--- a/test-apd.scm
+++ b/test-apd.scm
@@ -1,0 +1,19 @@
+(define (apd xs ys)
+  (if (null? xs) ys (cons (car xs) (apd (cdr xs) ys))))
+
+(define (apd3 xs ys zs) (apd (apd xs ys) zs))
+
+(define (rev xs sx) (if (null? xs) sx (rev (cdr xs) (cons (car xs) sx))))
+(define (reverse xs) (rev xs '()))
+
+(define (shmota n) (if (= n 0) '(0) (cons n (shmota (- n 1)))))
+(define (iota n) (reverse (shmota (- n 1))))
+
+(define (map1 f xs) (if (null? xs) '() (cons (f (car xs)) (map1 f (cdr xs)))))
+
+(define (jedziemy n m)
+  (map1 (lambda (_)
+         (apd3 (iota m) (iota m) (iota m)))
+       (iota n)))
+
+(jedziemy 1000 1000)

--- a/test-drc.scm
+++ b/test-drc.scm
@@ -1,0 +1,100 @@
+#!/usr/bin/guile \
+-L . -s
+!#
+(cond-expand
+ (guile
+  (import (base))
+  (define (writeln x) (write x) (newline) x))
+ (else))
+
+(define (forget n D)
+  (match D
+    ('() '())
+    (`((,k . ,v) . ,D*) (if (eq? k n)
+                            D*
+                            `((,k . ,v) . ,(forget n D*))))))
+
+(define (lookup n D)
+  (match D
+    ('() 'UNKNOWN-NAME)
+    (`((,k . ,v) . ,D*) (if (eq? k n)
+                            v
+                            (lookup n D*)))))
+
+(define (=>* d r c)
+;  (writeln `(D: ,d))
+;  (writeln `(R: ,r))
+;  (writeln `(C: ,c))
+;  (writeln '---)
+  (match `(,d ,r ,c)
+
+    (`(,D (,e . ,R) ((NAME ,n) . ,C))   (=>* `((,n . ,e) . ,D) R C))
+    (`(,D    ,R     ((FORGET ,n) . ,C)) (=>* (forget n D) R C))
+    (`(,D    ,R     ((LOOKUP ,n) . ,C)) (=>* D `(,(lookup n D) . ,R) C))
+
+    (`(,D ,R ((CONST ,e) . ,C)) (=>* D `(,e . ,R) C))
+    (`(,D ,R ((PROC ,p)  . ,C)) (=>* D `(,p . ,R) C))
+
+    (`(,D ((,h . ,t) . ,R) ((CAR) . ,C)) (=>* D `(,h . ,R) C))
+    (`(,D ((,h . ,t) . ,R) ((CDR) . ,C)) (=>* D `(,t . ,R) C))
+    (`(,D (,h ,t . ,R) ((CONS) . ,C)) (=>* D `((,h . ,t) . ,R) C))
+    (`(,D (,n ,m . ,R) ((PLUS) . ,C)) (=>* D `(,(+ n m) . ,R) C))
+    (`(,D (,n ,m . ,R) ((MINUS) . ,C)) (=>* D `(,(- n m) . ,R) C))
+    (`(,D (,n ,m . ,R) ((TIMES) . ,C)) (=>* D `(,(* n m) . ,R) C))
+
+    ;(`(,D (,x ,x . ,R) ((EQ?) . ,C)) (=>* D `(T . ,R) C))
+    ;(`(,D (,x ,y . ,R) ((EQ?) . ,C)) (=>* D `(() . ,R) C))
+    (`(,D (,x ,y . ,R) ((EQ?) . ,C))  (=>* D `(,(if (equal? x y) 'T '()) . ,R) C))
+
+    (`(,D ((,h . ,t) . ,R) ((ATOM?) . ,C)) (=>* D `(() . ,R) C))
+    (`(,D (   ,a     . ,R) ((ATOM?) . ,C)) (=>* D `(T . ,R) C))
+    (`(,D ((? number?) . ,R) ((NUM?) . ,C)) (=>* D `(T . ,R) C))
+    (`(,D (    ,x      . ,R) ((NUM?) . ,C)) (=>* D `(() . ,R) C))
+    (`(,D ((? symbol?) . ,R) ((SYM?) . ,C)) (=>* D `(T . ,R) C))
+    (`(,D (    ,x      . ,R) ((SYM?) . ,C)) (=>* D `(() . ,R) C))
+
+    (`(,D (() . ,R) ((SELECT ,p ,p*) . ,C)) (=>* D R `(,@p* ,@C)))
+    (`(,D ( T . ,R) ((SELECT ,p ,p*) . ,C)) (=>* D R `(,@p ,@C)))
+
+    (`(,D (,p . ,R) ((APPLY) . ,C)) (=>* D R `(,@p ,@C)))
+
+    (`(,D (,r . ,R) ()) r)))
+
+(define p1
+  '((PROC ((NAME xs)
+           (NAME ys)
+           (LOOKUP xs)
+           (CONST ())
+           (EQ?)
+           (SELECT ((LOOKUP ys))
+                   ((LOOKUP ys)
+                    (LOOKUP xs)
+                    (CDR)
+                    (LOOKUP apd)
+                    (APPLY)
+                    (LOOKUP xs)
+                    (CAR)
+                    (CONS)))
+           (FORGET ys)
+           (FORGET xs)))
+    (NAME apd)
+    (LOOKUP apd)
+    (APPLY)
+    (LOOKUP apd)
+    (APPLY)
+    (LOOKUP apd)
+    (APPLY)
+    (LOOKUP apd)
+    (APPLY)))
+
+(define (DRC program data) (=>* '() data program))
+
+(define (shmota n acc) (if (= n 0) acc (shmota (- n 1) (cons n acc))))
+(define (iota n) (shmota n '()))
+
+(define (map1 f xs)
+  (if (null? xs) '() (cons (f (car xs)) (map1 f (cdr xs)))))
+
+(map1 (lambda (_)
+       (DRC p1 '((m o r) (d e r c z a) (m a) (k u l a) (t u r a))))
+     (iota 10000))


### PR DESCRIPTION
zamiana arajów na konsy ze spodziewaną poprawą śmigalności, tj:

| test | było [s] | jest [s] |
| --- | --- | --- |
| test-apd.scm | 35.9 | 0.8 |
| test-drc.scm | 64.5 | 22.9 |
| test-ack.scm | 287.0 | 289.8 |
| diag(jsssssssss.scm) | 3.1 | 2.3 |

_tego test-drc to trzeba `--stack_size=4444` albo coś około_
przy okazji drobne poprawki lewego folda i serializacyi.
