### PR TITLE
ograniczony zasięg psucia runtime/ z poziomu programu źródłowego

### DIFF
--- a/more-tests-expected-outputs
+++ b/more-tests-expected-outputs
@@ -262,3 +262,10 @@ every---------
 #t
 #f
 #t
+immune-to-redefining-primops?
+ok
+ok
+ok
+(q w e a b c)
+(q w e a b c)
+(q w e a b c)

--- a/more-tests.scm
+++ b/more-tests.scm
@@ -485,3 +485,19 @@
 (writeln (every even? '(0 2 4 6)))
 (writeln (every even? '(0 2 4 5)))
 (writeln (every even? '()))
+
+(writeln 'immune-to-redefining-primops?)
+
+(writeln (if (member x '(1 2 3)) 'wtf 'ok))
+(define old-equal? equal?)
+(define (equal? . _) #t)
+(writeln (if (member x '(1 2 3)) 'oops 'ok))
+(define equal? old-equal?)
+(writeln (if (member x '(1 2 3)) 'wtf 'ok))
+
+(writeln (append '(q w e) '(a b c)))
+(define old-pair? pair?)
+(define (pair? _) #f)
+(writeln (append '(q w e) '(a b c)))
+(define pair? old-pair?)
+(writeln (append '(q w e) '(a b c)))

--- a/runtime/lists.js
+++ b/runtime/lists.js
@@ -1,36 +1,44 @@
-const __nil = Symbol();
+/////////////////////////////////////////////////////////////////////
+// LISTS
 
-var pair$Qu = x => (typeof(x) == 'object' && 'car' in x && 'cdr' in x);
+const __is_list = x => {
+    while(__is_pair(x)) x=x.cdr;
+    return __is_nil(x);
+};
 
-var cons = (h,t) => {return {car: h, cdr: t}; };
+/////////////////////////////////////////////////////////////////////
+
+var pair$Qu = __is_pair;
+var cons = __cons;
+
 var car = p => p.car;
 var cdr = p => p.cdr;
 var cadr = p => p.cdr.car;
 
-var null$Qu = x => x===__nil;
+var null$Qu = __is_nil;
 
-var list$Qu = x => (null$Qu(x) || pair$Qu(x) && list$Qu(x.cdr));
+var list$Qu = __is_list;
 
 var append = (...xs) => {
-    xs = xs.filter(x=>!null$Qu(x));
+    xs = xs.filter(x=>x!==__nil);
     if(xs.length<1) return __nil;
     var res = xs[xs.length-1];
     for(var i=xs.length-2;i>=0;i--) {
-        var tmp = list$Mn$Gtvector(xs[i]);
+        var tmp = __list2vector(xs[i]);
         for(var j=tmp.length-1;j>=0;j--) {
-            res = cons(tmp[j],res);
+            res = __cons(tmp[j],res);
         }
     }
     return res
 };
 
 var append$Ex = (...xs) => {
-    xs = xs.filter(x=>!null$Qu(x));
+    xs = xs.filter(x=>x!==__nil);
     if(xs.length<1) return __nil;
     for(var i=0;i<xs.length-1;i++) {
         var p = xs[i];
-        while(pair$Qu(p)) {
-            if(null$Qu(p.cdr)) {
+        while(__is_pair(p)) {
+            if(__is_nil(p.cdr)) {
                 p.cdr = xs[i+1];
                 break;
             }
@@ -42,34 +50,34 @@ var append$Ex = (...xs) => {
 
 var length = xs => {
     var len = 0;
-    while(pair$Qu(xs)) { xs = xs.cdr ; len += 1; }
-    if(null$Qu(xs)) return len;
-    else throw "length wrong type argument";
+    while(__is_pair(xs)) { xs = xs.cdr ; len += 1; }
+    if(__is_nil(xs)) return len;
+    else throw new Error("length wrong type argument");
 };
 
-var list = (...xs) => vector$Mn$Gtlist(xs);
+var list = (...xs) => __vector2list(xs);
 
 var member = (e, l) => {
-    while(pair$Qu(l)) {
-        if(equal$Qu(e, l.car)) return l;
+    while(__is_pair(l)) {
+        if(__equal2(e, l.car)) return l;
         l = l.cdr;
     }
     return false;
 };
 
 var drop = (n, l) => {
-    while(n>0 && pair$Qu(l)) { l = l.cdr; n -= 1; }
+    while(n>0 && __is_pair(l)) { l = l.cdr; n -= 1; }
     return l;
 };
 
 var take = (n, l) => {
     var q = [];
-    while(n>0 && pair$Qu(l)) {q.push(l.car); l = l.cdr; n -= 1;}
-    return vector$Mn$Gtlist(q);
+    while(n>0 && __is_pair(l)) {q.push(l.car); l = l.cdr; n -= 1;}
+    return __vector2list(q);
 };
 
 var any = (pred, l) => {
-    while(pair$Qu(l)) {
+    while(__is_pair(l)) {
         var res = pred(l.car);
         if(res!==false) return res;
         l = l.cdr;
@@ -78,7 +86,7 @@ var any = (pred, l) => {
 };
 
 var every = (pred, l) => {
-    while(pair$Qu(l)) {
+    while(__is_pair(l)) {
         if(pred(l.car)===false) return false;
         l = l.cdr;
     }
@@ -86,32 +94,32 @@ var every = (pred, l) => {
 };
 
 var assoc = (key, alist) => {
-    while(pair$Qu(alist)) {
-	    if(equal$Qu(alist.car.car, key)) return alist.car;
+    while(__is_pair(alist)) {
+	    if(__equal2(alist.car.car, key)) return alist.car;
 	    alist = alist.cdr;
     }
     return false;
 };
 
 var for$Mneach = (f, l) => {
-    while(pair$Qu(l)) { f(l.car); l=l.cdr; }
+    while(__is_pair(l)) { f(l.car); l=l.cdr; }
 };
 
 var map = (f, ...ls) => {
     var res = [];
-    while(pair$Qu(ls[0])) {
-        var args = ls.map(x => car(x));
+    while(__is_pair(ls[0])) {
+        var args = ls.map(x => x.car);
         res.push(f.apply(null,args));
-        ls = ls.map(x => cdr(x));        
+        ls = ls.map(x => x.cdr);        
     }
-    return vector$Mn$Gtlist(res);
+    return __vector2list(res);
 }
 
-var only = (pred, l) => vector$Mn$Gtlist(list$Mn$Gtvector(l).filter(pred));
+var only = (pred, l) => __vector2list(__list2vector(l).filter(pred));
 
 var fold$Mnleft = (op, init, l) => {
     var acc = init;
-    while(pair$Qu(l)) {
+    while(__is_pair(l)) {
         acc = op(acc, l.car);
         l = l.cdr;
     }
@@ -127,21 +135,21 @@ var union = (...sets) => {
     }
     var set = {};
     for (var s of sets) {
-	    for (var x of list$Mn$Gtvector(s)) {
-	        set[serialize(x)] = x;
+	    for (var x of __list2vector(s)) {
+	        set[__serialize(x)] = x;
 	    }
     }
     var result = [];
     for (var k in set) {
 	result.push(set[k]);
     }
-    return vector$Mn$Gtlist(result);
+    return __vector2list(result);
 };
 
 var difference = (a, b) => {
     var bset = {};
-    for (var x of list$Mn$Gtvector(b)) {
-	bset[serialize(x)] = 1;
+    for (var x of __list2vector(b)) {
+	bset[__serialize(x)] = 1;
     }
-    return vector$Mn$Gtlist(list$Mn$Gtvector(a).filter(x=> !(serialize(x) in bset)));
+    return __vector2list(__list2vector(a).filter(x=> !(__serialize(x) in bset)));
 };

--- a/runtime/numbers.js
+++ b/runtime/numbers.js
@@ -1,13 +1,14 @@
-var number$Qu = x => typeof(x) == 'number';
+/////////////////////////////////////////////////////////////////////
+// NUMBERS
 
-var number$Mn$Gtstring = (e, radix=10) => {
+const __number2string = (e, radix=10) => {
     if (isFinite(e)) return e.toString(radix);
     if (e > 0) return "+inf.0";
     if (e < 0) return "-inf.0";
     return "+nan.0";
 };
 
-var string$Mn$Gtnumber = (s, radix=10) => {
+const __string2number = (s, radix=10) => {
     if (s == "+inf.0") return Infinity;
     if (s == "-inf.0") return -Infinity;
     if (s == "+nan.0") return NaN;
@@ -18,8 +19,15 @@ var string$Mn$Gtnumber = (s, radix=10) => {
     return parseInt(s, radix);
 };
 
+/////////////////////////////////////////////////////////////////////
+
+var number$Qu = __is_number;
+
 var finite$Qu = isFinite;
 var nan$Qu = isNaN;
 
-var even$Qu = n => number$Qu(n) && n%2==0;
-var odd$Qu = n => number$Qu(n) && n%2==1;
+var even$Qu = n => n%2==0;
+var odd$Qu = n => n%2==1;
+
+var number$Mn$Gtstring = __number2string;
+var string$Mn$Gtnumber = __string2number;

--- a/runtime/parameters.js
+++ b/runtime/parameters.js
@@ -1,10 +1,19 @@
-var make$Mnparameter = (init) => {
+/////////////////////////////////////////////////////////////////////
+// PARAMETERS
+
+const __make_parameter = (init) => {
     var s = [init];
     var axs=(...a)=>(a.length==0)?s[s.length-1]:s[s.length-1]=a[0];
     axs.stack = s;
     return axs;
 };
 
-var push$Mnparameter = (param, value) => param.stack.push(value);
+const __push_parameter = (param, value) => param.stack.push(value);
 
-var pop$Mnparameter = (param) => param.stack.pop();
+const __pop_parameter = (param) => param.stack.pop();
+
+/////////////////////////////////////////////////////////////////////
+
+var make$Mnparameter = __make_parameter;
+var push$Mnparameter = __push_parameter;
+var pop$Mnparameter = __pop_parameter;

--- a/runtime/ports.js
+++ b/runtime/ports.js
@@ -1,3 +1,6 @@
+/////////////////////////////////////////////////////////////////////
+// PORTS
+
 var input$Mnport$Qu = x => typeof(x) == 'object'
     && typeof(x.readChar) == 'procedure'
     && typeof(x.peekChar) == 'procedure'
@@ -127,11 +130,11 @@ let stdout = new OutputFilePort(1, "stdout");
 
 let stderr = new OutputFilePort(2, "stderr");
 
-var current$Mninput$Mnport = make$Mnparameter(stdin);
+var current$Mninput$Mnport = __make_parameter(stdin);
 
-var current$Mnoutput$Mnport = make$Mnparameter(stdout);
+var current$Mnoutput$Mnport = __make_parameter(stdout);
 
-var current$Mnerror$Mnport = make$Mnparameter(stderr);
+var current$Mnerror$Mnport = __make_parameter(stderr);
 
 var call$Mnwith$Mninput$Mnstring = (string, f) => {
     return f(new InputStringPort(string));
@@ -145,23 +148,23 @@ var call$Mnwith$Mnoutput$Mnstring = (f) => {
 
 var with$Mninput$Mnfrom$Mnstring = (string, f) => {
     let p = new InputStringPort(string);
-    push$Mnparameter(current$Mninput$Mnport, p);
+    __push_parameter(current$Mninput$Mnport, p);
     try {
 	return f();
     }
     finally {
-	pop$Mnparameter(current$Mninput$Mnport);
+	__pop_parameter(current$Mninput$Mnport);
     }
 };
 
 var with$Mnoutput$Mnto$Mnstring = (f) => {
     let p = new OutputStringPort();
-    push$Mnparameter(current$Mnoutput$Mnport, p);
+    __push_parameter(current$Mnoutput$Mnport, p);
     try {
 	f();
     }
     finally {
-	pop$Mnparameter(current$Mnoutput$Mnport);
+	__pop_parameter(current$Mnoutput$Mnport);
     }
     return p.string;
 };
@@ -212,24 +215,24 @@ var call$Mnwith$Mnoutput$Mnfile = (name, f) => {
 
 var with$Mninput$Mnfrom$Mnfile = (name, f) => {
     let p = open$Mninput$Mnfile(name);
-    push$Mnparameter(current$Mninput$Mnport, p);
+    __push_parameter(current$Mninput$Mnport, p);
     try {
 	return f();
     }
     finally {
-	pop$Mnparameter(current$Mninput$Mnport);
+	__pop_parameter(current$Mninput$Mnport);
 	p.close();
     }
 };
 
 var with$Mnoutput$Mnto$Mnfile = (name, f) => {
     let p = open$Mnoutput$Mnfile(name);
-    push$Mnparameter(current$Mnoutput$Mnport, p);
+    __push_parameter(current$Mnoutput$Mnport, p);
     try {
 	return f();
     }
     finally {
-	pop$Mnparameter(current$Mnoutput$Mnport);
+	__pop_parameter(current$Mnoutput$Mnport);
 	p.close();
     }
 };

--- a/runtime/primops.js
+++ b/runtime/primops.js
@@ -1,3 +1,44 @@
+/////////////////////////////////////////////////////////////////////
+// PRIMOPS
+
+const __nil = Symbol();
+const __is_nil = x => x===__nil;
+
+const __is_number = x => typeof(x)=='number';
+const __is_boolean = x => typeof(x)=='boolean';
+const __is_procedure = x => typeof(x) == 'function';
+const __is_char = x => typeof(x) == 'object' && typeof(x.char) == 'string' && x.char.length == 1;
+const __is_string = x => typeof(x) == 'string';
+const __is_symbol = x => typeof(x) == 'object' && typeof(x.symbol) == 'string';
+const __is_vector = x => typeof(x) == 'object' && x.constructor == Array;
+const __is_pair = x => typeof(x) == 'object' && 'car' in x && 'cdr' in x;
+
+const __eqv2 = (a,b) => {
+    if(a===b) return true;
+    switch(true) {
+    case __is_nil(a): return __is_nil(b);
+    case __is_string(a) && __is_string(b):
+    case __is_number(a) && __is_number(b):
+    case __is_boolean(a) && __is_boolean(b):
+        return a===b;
+    case __is_symbol(a) && __is_symbol(b):
+        return a.symbol===b.symbol;
+    case __is_char(a) && __is_char(b):
+        return a.char===b.char;
+    default:
+        return false;
+    }
+};
+
+const __cons = (h,t) => {return {car: h, cdr: t}; };
+
+const __apply = (f, ...args) => {
+    var collected = args.slice(0, args.length-1)
+        .concat(__list2vector(args[args.length-1]));
+    return f.apply(null, collected);
+};
+
+
 var mk_seq_rel = rel => (...xs) => {
     for(var i = 1; i < xs.length; ++i) {
 	if(!rel(xs[i-1], xs[i])) return false;
@@ -5,22 +46,12 @@ var mk_seq_rel = rel => (...xs) => {
     return true;
 };
 
+/////////////////////////////////////////////////////////////////////
 
-var boolean$Qu = x => typeof(x) == 'boolean';
+var boolean$Qu = __is_boolean;
 
-var eqv$Qu = mk_seq_rel(
-    (a, b) =>
-    (null$Qu(a) && null$Qu(b))
-	|| (symbol$Qu(a) && symbol$Qu(b)
-	    && a.symbol == b.symbol)
-	|| (boolean$Qu(a) && boolean$Qu(b) && a == b)
-	|| (number$Qu(a) && number$Qu(b) && a == b)
-	|| (char$Qu(a) && char$Qu(b) && a.char == b.char)
-	|| a === b
-);
-
+var eqv$Qu = mk_seq_rel(__eqv2);
 var eq$Qu = eqv$Qu;
-
 var $Eq = eq$Qu;
 
 var $Pl = (...xs) => xs.reduce((n,m) => n+m, 0);
@@ -41,10 +72,6 @@ var $Gt$Eq = mk_seq_rel((n,m) => n >= m);
 
 var $Ls$Eq = mk_seq_rel((n,m) => n <= m);
 
-var apply = (f, ...args) => {
-    var collected = args.slice(0, args.length-1)
-        .concat(list$Mn$Gtvector(args[args.length-1]));
-    return f.apply(null, collected);
-};
+var apply = __apply;
 
-var procedure$Qu = x => typeof(x) == 'function';
+var procedure$Qu = __is_procedure;

--- a/runtime/serialize.js
+++ b/runtime/serialize.js
@@ -1,23 +1,37 @@
-var serialize = e => {
+/////////////////////////////////////////////////////////////////////
+// SERIALIZE
+
+const __char_name = c => {
+    let i = c.char.codePointAt(0);
+    if (i < 16) {
+	return "x0"+i.toString(16);
+    }
+    if (i <= 32) {
+	return "x"+i.toString(16);
+    }
+    return c.char;
+};
+
+const __serialize = e => {
     switch(true) {
-    case null$Qu(e): return "()";
-    case boolean$Qu(e): return e ? "#t" : "#f";
-    case number$Qu(e): return number$Mn$Gtstring(e);
-    case char$Qu(e): return "#\\"+charName(e);
-    case symbol$Qu(e): return symbol$Mn$Gtstring(e);
-    case string$Qu(e): return JSON.stringify(e);
-    case vector$Qu(e): return "#("+e.map(serialize).join(" ")+")";
-    case pair$Qu(e):
+    case __is_nil(e): return "()";
+    case __is_boolean(e): return e ? "#t" : "#f";
+    case __is_number(e): return __number2string(e);
+    case __is_char(e): return "#\\"+__char_name(e);
+    case __is_symbol(e): return __symbol2string(e);
+    case __is_string(e): return JSON.stringify(e); /// :)
+    case __is_vector(e): return "#("+e.map(__serialize).join(" ")+")";
+    case __is_pair(e):
         var str = "(";
         while(true) {
-            str += serialize(e.car);
-            if(null$Qu(e.cdr)) { return str + ")"; }
+            str += __serialize(e.car);
+            if(e.cdr===__nil) { return str + ")"; }
             str += " ";
-            if(pair$Qu(e.cdr)) { e = e.cdr; }
-            else { return str += ". " + serialize(e.cdr) + ")"; }
+            if(__is_pair(e.cdr)) { e = e.cdr; }
+            else { return str += ". " + __serialize(e.cdr) + ")"; }
         }
-    case procedure$Qu(e): return "#<"+e.toString()+">";
-    case eof$Mnobject$Qu(e): return "#<eof-object>";
+    case __is_procedure(e): return "#<"+e.toString()+">";
+    case __is_eof_object(e): return "#<eof-object>";
     default:
 	if (typeof(e) == 'object') {
 	    if (e.constructor.name == "Object") {
@@ -29,46 +43,62 @@ var serialize = e => {
     }
 };
 
-let arrays$Mnequal$Qu = (a, b) => {
+const __arrays_equal = (a, b) => {
     if (a.length != b.length) return false;
     for (var i = 0; i < a.length; ++i) {
-	    if (!equal$Qu(a[i], b[i])) {
+	    if (!__equal2(a[i], b[i])) {
 	        return false;
 	    }
     }
     return true;
-}
+};
 
-let objects$Mnequal$Qu = (a, b) => {
+const __objects_equal = (a, b) => {
     var a_keys = Object.keys(a);
     var b_keys = Object.keys(b);
     if (a_keys.length != b_keys.length) return false;
     for (var x of a_keys) {
-	    if (!(x in b) || !equal$Qu(a[x], b[x])) return false;
+	    if (!(x in b) || !__equal2(a[x], b[x])) return false;
     }
     return true;
-}
-
-var __equal2 = (x,y) => (x === y ||
-                         (typeof(x)==typeof(y) &&
-                         ((typeof(x)=='object' && objects$Mnequal$Qu(x,y))
-                          || (pair$Qu(x) && pair$Qu(y) &&
-                            __equal2(x.car, y.car) &&
-                            __equal2(x.cdr, y.cdr)))));
-var equal$Qu = mk_seq_rel(__equal2);
-
-let stringify = (e) => string$Qu(e)?e:serialize(e);
-
-var writeln = (...args) => {
-    console.log(args.map(stringify).join(''));
 };
 
-var error = (...msg) => { throw new Error(msg.map(stringify).join('')); };
+const __equal2 = (x,y) => {
+    if(x===undefined) return y===undefined;
+    if(x.constructor===y.constructor) {
+        return (__eqv2(x,y) ||                           
+                (x.constructor==Array && __arrays_equal(x,y)) ||
+                (x.constructor==Object &&
+                 (('car' in x && 'cdr' in x &&
+                   'car' in y && 'cdr' in y &&
+                   __equal2(x.car, y.car) &&
+                   __equal2(x.cdr, y.cdr))
+                  || __objects_equal(x,y))))
+    }
+    return false;
+};
+
+/////////////////////////////////////////////////////////////////////
+
+var serialize = __serialize;
+let arrays$Mnequal$Qu = __arrays_equal;
+
+let objects$Mnequal$Qu = __objects_equal;
+
+var equal$Qu = mk_seq_rel(__equal2);
+
+let __stringify = (e) => __is_string(e)?e:__serialize(e); /// hmm.
+
+var writeln = (...args) => {
+    console.log(args.map(__stringify).join(''));
+};
+
+var error = (...msg) => { throw new Error(msg.map(__stringify).join('')); };
 
 var assert = c => { if(!c) {error("Assertion failed");} };
 
 var invalid$Mnexample =
-    make$Mnparameter((expression, actual, expected) =>
+    __make_parameter((expression, actual, expected) =>
 	(typeof(expected) == 'undefined')
 	    ? error("expected ",expression," to be non-#false")
 	    : error("while evaluating\n\n  ",
@@ -79,7 +109,8 @@ var invalid$Mnexample =
 		    actual, "\n"))
 
 var valid$Mnexample =
-    make$Mnparameter((expression, actual, expected) => actual)
+    __make_parameter((expression, actual, expected) => actual)
 
-var slot$Mnref = (x, prop) => x[symbol$Mn$Gtstring(prop)];
-var slot$Mnset$Ex = (x, prop, v) => x[symbol$Mn$Gtstring(prop)] = v;
+var slot$Mnref = (x, prop) => x[__symbol2string(prop)];
+
+var slot$Mnset$Ex = (x, prop, v) => x[__symbol2string(prop)] = v;

--- a/runtime/strings.js
+++ b/runtime/strings.js
@@ -1,17 +1,10 @@
-var char$Qu = x => typeof(x) == 'object'
-    && typeof(x.char) == 'string'
-    && x.char.length == 1;
-
-var string$Qu = x => typeof(x) == 'string';
-
-var symbol$Qu = x => typeof(x) == 'object'
-    && typeof(x.symbol) == 'string';
+/////////////////////////////////////////////////////////////////////
+// STRINGS
 
 const __EOF = {char: false};
+const __is_eof_object = x => (x === __EOF);
 
-var eof$Mnobject$Qu = x => x === __EOF;
-
-var symbol$Mn$Gtstring = s => {
+const __symbol2string = s => {
     if (typeof(s.symbol) == 'undefined') {
 	throw new Error("not a symbol: "+s);
     }
@@ -33,9 +26,9 @@ var symbol$Mn$Gtstring = s => {
 	.replace(/[$]Dt/g, ".")
 	.replace(/[$]Am/g, "&")
 	.replace(/[$]Nm/g, "#");
-}
+};
 
-var string$Mn$Gtsymbol = s => {
+const __string2symbol = s => {
     var name = (s == "for")
 	? "$Kwfor"
 	: (s.replace(/^([0-9])/, "$$N$1")
@@ -57,33 +50,31 @@ var string$Mn$Gtsymbol = s => {
     return { symbol: name };
 };
 
-var list$Mn$Gtstring = s => list$Mn$Gtvector(s).map(c => c.char).join('');
+/////////////////////////////////////////////////////////////////////
 
-var string$Mn$Gtlist = s => vector$Mn$Gtlist(s.split('').map(c =>{ return {char: c} }));
+var char$Qu = __is_char;
+var string$Qu = __is_string;
+var symbol$Qu = __is_symbol;
+var eof$Mnobject$Qu = __is_eof_object;
+
+var symbol$Mn$Gtstring = __symbol2string;
+var string$Mn$Gtsymbol = __string2symbol;
+
+var list$Mn$Gtstring = s => __list2vector(s).map(c => c.char).join('');
+var string$Mn$Gtlist = s => __vector2list(s.split('').map(c =>{ return {char: c} }));
 
 var string$Mnappend = (...args) => args.join('');
 
 var string$Mnjoin = (strings, joint='') => {
     res = "";
-    while(pair$Qu(strings)) {
-        if(!string$Qu(strings.car)) throw "string-join wrong type argument";
+    while(__is_pair(strings)) {
+        if(!__is_string(strings.car)) throw new Error("string-join wrong type argument");
         res += strings.car;
         strings = strings.cdr;
-        if(null$Qu(strings)) return res;
-        if(!pair$Qu(strings)) throw "string-join wrong type argument";
+        if(__is_nil(strings)) return res;
+        if(!__is_pair(strings)) throw new Error("string-join wrong type argument");
         res += joint;
     }
-};
-
-let charName = c => {
-    let i = c.char.codePointAt(0);
-    if (i < 16) {
-	return "x0"+i.toString(16);
-    }
-    if (i <= 32) {
-	return "x"+i.toString(16);
-    }
-    return c.char;
 };
 
 var string$Mnref = (s, i) => { return {char: s[i]}; };
@@ -107,6 +98,6 @@ var string$Mnreplace$Mnsubstring = (s, p, r) =>
 			 'g'), r);
 
 
-var char$Mnnumeric$Qu = x => char$Qu(x) && /[0-9]/.test(x.char);
+var char$Mnnumeric$Qu = x => __is_char(x) && /[0-9]/.test(x.char);
 
-var string$Eq$Qu = mk_seq_rel((x,y) => string$Qu(x) && string$Qu(y) && x==y)
+var string$Eq$Qu = mk_seq_rel((x,y) => __is_string(x) && __is_string(y) && x===y);

--- a/runtime/vectors.js
+++ b/runtime/vectors.js
@@ -1,19 +1,29 @@
-var vector$Qu = x => typeof(x) == 'object' && Array.isArray(x);
+/////////////////////////////////////////////////////////////////////
+// VECTORS
+
+const __list2vector = l => {
+    if(!__is_list(l)) throw "list->vector wrong type argument";
+    var ll = length(l);
+    var v = Array(ll);
+    for(var i=0;i<ll;i++) { v[i] = l.car; l = l.cdr; }
+    return v;
+};
+
+const __vector2list = v => {
+    var l = __nil;
+    for(var i=v.length-1; i>=0; i--) l = {car: v[i], cdr: l};
+    return l;
+};
+
+/////////////////////////////////////////////////////////////////////
+
+var vector$Qu = __is_vector;
 
 var make$Mnvector = (k,f) => { return Array(k).fill(f); };
 var vector = (...xs) => {return xs; };
 
-var list$Mn$Gtvector = l => {
-    var v = Array(length(l));
-    for(var i=0;i<v.length;i++) { v[i] = l.car; l = l.cdr; }    
-    return v;
-};
-
-var vector$Mn$Gtlist = v => {
-    var l = __nil;
-    for(var i=v.length-1; i>=0; i--) { l = cons(v[i],l); }
-    return l;
-};
+var list$Mn$Gtvector = __list2vector;
+var vector$Mn$Gtlist = __vector2list;
 
 var vector$Mnlength = v => v.length;
 


### PR DESCRIPTION
nie jest to za piękne, ale robi robotę (a więc np przedefiniowując `equal?` czy `pair?` nie knoci się działania `member` , `length` czy `append` c'nie). pewnie więc lepiej takie coś mieć niż nie (albo właśnie lepiej takiego czegoś nie mieć?).
może Pan zawsze zmarnować niedzielny kwadracik na rywju z pretensjami to coś mogę poprawić (a od biedy sprawdzę jutro też mejla).
obadałem ręcznie czy inlajnowanie tych procedur z dwoma podkreślnikami dużo daje no i NA SZCZĘŚCIE nie (bo inaczej by trzeba napisać inliner jako że Brendan nie raczył). no i to na razie tyle bo mimo wszystko trochę se dziś czytam.
